### PR TITLE
Small fixes

### DIFF
--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -12,7 +12,7 @@
 
       <p>
         To download desktop applications on a modern Linux-based system,
-        <a href="https://flathub.org/repo/flathub.flatpakrepo">download</a> the repository file and add it to your system with GNOME Software or the Flatpak command line.
+        <a href="https://dl.flathub.org/repo/flathub.flatpakrepo">download</a> the repository file and add it to your system with GNOME Software or the Flatpak command line.
       </p>
     </div>
   </header>
@@ -27,13 +27,13 @@
     <p>
       If you are on Arch, Debian Stretch (or later), Endless OS, Fedora 25 (or later), Mageia 6 (or later), or OpenSUSE Tumbleweed,
       you can
-      <a href="https://flathub.org/repo/flathub.flatpakrepo">download</a> the repository file and use GNOME Software to install it.
+      <a href="https://dl.flathub.org/repo/flathub.flatpakrepo">download</a> the repository file and use GNOME Software to install it.
     </p>
     <h2 id="using">Using Flathub on the Command Line</h2>
     <p>
       From the command line, run:
     </p>
-    <pre><span class="unselectable">$ </span>flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+    <pre><span class="unselectable">$ </span>flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
     </pre>
     <p>
       You can then browse and install applications in the normal manner. See the Flatpak

--- a/src/app/shared/app-details-install-instructions/app-details-install-instructions.component.html
+++ b/src/app/shared/app-details-install-instructions/app-details-install-instructions.component.html
@@ -5,24 +5,24 @@
     <h5>Click to download</h5>
     <ol>
       <li>If you don't have it already, you'll need to
-        <a href="http://flatpak.org/getting.html">&nbsp;get Flatpak</a>
+        <a href="http://flatpak.org/getting.html">&nbsp;get Flatpak.</a>
       </li>
       <li>For Flatpak versions &lt; 0.10.0 it is also recommended to add the flathub repository first. You can
-        <a href="https://flathub.org/repo/flathub.flatpakrepo">&nbsp;download&nbsp;</a>the repository file and use your distribution's software manager (GNOME Software, KDE Discover,
+        <a href="https://dl.flathub.org/repo/flathub.flatpakrepo">&nbsp;download&nbsp;</a>the repository file and use your distribution's software manager (GNOME Software, KDE Discover,
         ...) to install it.</li>
-      <li>Click on the INSTALL button</li>
-      <li>Your distibution's software manager will open automatically and will install the app</li>
+      <li>Click on the INSTALL button.</li>
+      <li>Your distibution's software manager will open automatically and will install the app.</li>
       <li>Once installed, applications can be launched from the usual place in your desktop. </li>
     </ol>
     <p>Click to download is available on Arch, Debian Stretch (or later), Endless OS, Fedora 25 (or later), Mageia 6 (or later),
-      and OpenSUSE Tumbleweed</p>
+      and OpenSUSE Tumbleweed.</p>
     <h5>Command line</h5>
     <ol>
       <li>If you don't have it already, you'll need to
-        <a href="http://flatpak.org/getting.html">&nbsp;get Flatpak</a>
+        <a href="http://flatpak.org/getting.html">&nbsp;get Flatpak.</a>
       </li>
       <li>Run this on the command line:
-        <pre>flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+        <pre>flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 flatpak install --from {{getDownloadFlatpakRefUrl()}}</pre>
       </li>
       <li>Once installed, applications can be launched from the usual place in your desktop. </li>


### PR DESCRIPTION
- Use dl.flathub.org for the flathub.flatpakrepo url. (See [this commit](https://github.com/flathub/flathub.org/commit/9d29d0394d85464938abd8495de1174ee5e0e279).)
- Add missing dots to information on the application details page.